### PR TITLE
use SecureRandom.urlsafe_base64

### DIFF
--- a/lib/rack/csrf.rb
+++ b/lib/rack/csrf.rb
@@ -56,7 +56,7 @@ module Rack
     end
 
     def self.token(env)
-      env['rack.session'][key] ||= SecureRandom.base64(32)
+      env['rack.session'][key] ||= SecureRandom.urlsafe_base64(32)
     end
 
     def self.tag(env)


### PR DESCRIPTION
CSRF tokens can be used for OAuth redirect grants, so it is helpful if the token is url safe.

@baldowl 