### PR TITLE
Use lowercase headers on Rack 3

### DIFF
--- a/lib/rack/csrf.rb
+++ b/lib/rack/csrf.rb
@@ -3,6 +3,9 @@ require 'securerandom'
 
 module Rack
   class Csrf
+    CONTENT_TYPE = (Rack.release >= '2.3' ? 'content-type' : 'Content-Type').freeze
+    CONTENT_LENGTH = (Rack.release >= '2.3' ? 'content-length' : 'Content-Length').freeze
+
     class SessionUnavailable < StandardError; end
     class InvalidCsrfToken < StandardError; end
 
@@ -38,7 +41,7 @@ module Rack
         @app.call(env)
       else
         fail InvalidCsrfToken if @raise_if_invalid
-        [403, {'Content-Type' => 'text/html', 'Content-Length' => '0'}, []]
+        [403, {CONTENT_TYPE => 'text/html', CONTENT_LENGTH => '0'}, []]
       end
     end
 


### PR DESCRIPTION
The Rack SPEC is changing in Rack 3 to not allow uppercase
ASCII in response headers (it's also changing to require
response headers to be an unfrozen hash).  This change
should allow rack_csrf to follow the Rack 3 SPEC.  For
backwards compatibility, it does not change the behavior when
used with older versions of Rack.

This checks for Rack 2.3 instead of Rack 3, since Rack that's
the current Rack main branch version.  However, the next Rack
version will be Rack 3.0, not Rack 2.3.

An alternative approach to this that would be more compatible
would be to use Rack::Headers if available (this has been added
to the Rack main branch, and will ship with Rack 3).  This allows
for case-insensitive access to the headers.