### PR TITLE
When using Rack 3, only load rack/request and rack/utils

### DIFF
--- a/lib/rack/csrf.rb
+++ b/lib/rack/csrf.rb
@@ -1,4 +1,10 @@
-require 'rack'
+require 'rack/version'
+if Rack.release >= '2.3'
+  require 'rack/request'
+  require 'rack/utils'
+else
+  require 'rack'
+end
 require 'securerandom'
 
 module Rack

--- a/lib/rack/csrf.rb
+++ b/lib/rack/csrf.rb
@@ -1,9 +1,14 @@
-require 'rack/version'
-if Rack.release >= '2.3'
-  require 'rack/request'
-  require 'rack/utils'
-else
+begin
+  require 'rack/version'
+rescue LoadError
   require 'rack'
+else
+  if Rack.release >= '2.3'
+    require 'rack/request'
+    require 'rack/utils'
+  else
+    require 'rack'
+  end
 end
 require 'securerandom'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,4 @@ require 'rubygems'
 require 'rspec'
 
 require 'rack/csrf'
+require 'rack/mock'


### PR DESCRIPTION
These are the only parts of Rack that rack_csrf uses.  Starting in
Rack 3, it is recommended that users of Rack load the parts of
Rack they are using, instead of requiring rack itself and relying
on the autoloads it adds.

In Rack <3, still load rack itself, since loading parts of Rack
was not guaranteed to work in earlier versions.

Load rack/mock when testing, since the tests use Rack::MockRequest.